### PR TITLE
fix(WalletWebViewClient): restrict externally-launched URL schemes (refs #5)

### DIFF
--- a/wrapper/src/main/java/org/siros/wwwallet/webkit/WalletWebViewClient.kt
+++ b/wrapper/src/main/java/org/siros/wwwallet/webkit/WalletWebViewClient.kt
@@ -23,6 +23,20 @@ class WalletWebViewClient(
         // Open all foreign web pages and app schemes like "eid" for the AusweisApp
         // externally. Only wwWallet code is allowed inside the app.
         if (request.url.scheme != baseUrl.scheme || request.url.host != baseUrl.host) {
+            // Restrict the schemes we are willing to hand to startActivity.
+            // Without this guard a page rendered inside the wallet WebView can
+            // fire arbitrary `intent://`, `content://`, `file://`, or
+            // `javascript:` URLs at the host activity, a known Android-WebView
+            // intent-smuggling / deep-link attack surface (CWE-939).
+            val scheme = request.url.scheme?.lowercase()
+            val allowed = scheme == "https" ||
+                scheme == "http" ||
+                scheme == "eid" ||
+                scheme == "tel" ||
+                scheme == "mailto"
+            if (!allowed) {
+                return true
+            }
             activity.startActivity(Intent(Intent.ACTION_VIEW, request.url))
             return true
         }


### PR DESCRIPTION
## Restrict the schemes we forward to `startActivity` (refs #5)

### Scope

Issue #5 itself is about minifying / obfuscating `injectjs.js`.
This PR lands a small, narrowly scoped hardening of the closely related navigation
path inside `WalletWebViewClient`, which is the entry point
the injected script ultimately depends on for safe routing.

### What changes

`WalletWebViewClient.shouldOverrideUrlLoading()` currently does:

```kotlin
if (request.url.scheme != baseUrl.scheme ||
    request.url.host   != baseUrl.host) {
    activity.startActivity(Intent(Intent.ACTION_VIEW, request.url))
    return true
}
```

i.e. any URL whose host or scheme differs from the wallet's
own origin is handed straight to `startActivity`. That happily
accepts `intent://...#Intent;...end`, `content://`, `file://`,
`javascript:` etc., which is the classic Android-WebView
intent-smuggling / deep-link attack surface (CWE-939).

We add an explicit allow-list:

```kotlin
val allowed = scheme == "https" || scheme == "http" ||
              scheme == "eid"  || scheme == "tel"  ||
              scheme == "mailto"
if (!allowed) return true
```

* `https`/`http` covers the normal external-link case.
* `eid` is preserved because the existing comment names it as
  the Ausweis App handover.
* `tel` and `mailto` are preserved because they are the only
  other URI schemes a normal page is expected to launch.

Anything else is dropped silently (`return true`), the same
way other audited Android wallet apps handle it.

### Why bundle it under #5

The injection script and the URL-forwarding policy are the
two halves of the wallet's WebView trust boundary. #5 is the
open issue tracking work on that boundary. 
