### PR TITLE
Stop rotation from reloading the WebView (closes #14)

### DIFF
--- a/wrapper/src/main/AndroidManifest.xml
+++ b/wrapper/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:configChanges="keyboard|keyboardHidden"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|smallestScreenSize|uiMode"
             android:exported="true"
             android:theme="@style/Theme.Wwwallet">
 


### PR DESCRIPTION
## Stop rotation from reloading the WebView

Closes #14

### What changed

`wrapper/src/main/AndroidManifest.xml`

Add the orientation, screen size, and related configuration changes to the existing `android:configChanges` attribute on `MainActivity`. With these in place, Android no longer destroys and recreates the activity when the device rotates, so the hosted WebView keeps its document, its JavaScript state, and any signed-in user.

### Key snippet

```xml
<activity
    android:name=".MainActivity"
    android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|smallestScreenSize|uiMode"
    android:exported="true"
    android:theme="@style/Theme.Wwwallet">
```

### Why these flags

* `orientation` and `screenSize` are the pair Android requires to suppress activity recreation on rotation since API 13.
* `screenLayout` and `smallestScreenSize` cover foldables and split-screen transitions.
* `uiMode` covers system theme switches (day, night, car), which would otherwise also reset the WebView.
