### PR TITLE
Resize the WebView when the soft keyboard appears (closes #26)

### DIFF
--- a/wrapper/src/main/AndroidManifest.xml
+++ b/wrapper/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
             android:name=".MainActivity"
             android:configChanges="keyboard|keyboardHidden"
             android:exported="true"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.Wwwallet">
 
             <intent-filter>


### PR DESCRIPTION
## Resize the WebView when the soft keyboard appears

Closes #26

### What changed

`wrapper/src/main/AndroidManifest.xml`

Add `android:windowSoftInputMode="adjustResize"` to the `MainActivity` declaration. With this attribute the system shrinks the activity window when the soft keyboard opens, instead of panning it. The hosted WebView receives the new size, the page reflows, and the focused input stays visible above the keyboard.

### Key snippet

```xml
<activity
    android:name=".MainActivity"
    android:configChanges="keyboard|keyboardHidden"
    android:exported="true"
    android:windowSoftInputMode="adjustResize"
    android:theme="@style/Theme.Wwwallet">
```
